### PR TITLE
UPDATE: unit in queries for redis

### DIFF
--- a/promql/redis.yaml
+++ b/promql/redis.yaml
@@ -26,7 +26,7 @@ queries:
             pod=~'<service-name>.*'
           }
         )
-      unit: "kb/s"
+      unit: "bytes"
 
     memory_peak:
       query: >-
@@ -36,7 +36,7 @@ queries:
             pod=~'<service-name>.*'
           }
         )
-      unit: "kb/s"
+      unit: "bytes"
 
     keys_total:
       query: >-


### PR DESCRIPTION
UPDATE: unit in queries for redis from kb/s to bytes