### PR TITLE
Add Helm Chart for ToolJet - Open Source Low-Code Platform

### DIFF
--- a/charts/tooljet/.helmignore
+++ b/charts/tooljet/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/tooljet/Chart.yaml
+++ b/charts/tooljet/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: tooljet
+description: A Helm chart for deploying ToolJet, an open-source low-code platform
+type: application
+version: 0.1.0
+appVersion: "v2.15.0"  # Change to latest ToolJet version
+icon: https://avatars.githubusercontent.com/u/87657345?s=200&v=4
+
+keywords:
+  - tooljet
+  - low-code
+  - platform
+  - open-source
+
+home: https://tooljet.com/
+sources:
+  - https://github.com/ToolJet/ToolJet
+maintainers:
+  - name: madira mahanandi reddy
+    email: madhirereddy4@gmail.com

--- a/charts/tooljet/NOTES.txt
+++ b/charts/tooljet/NOTES.txt
@@ -1,0 +1,27 @@
+Crafted with 💻 and ☁️ by the community. Fork, deploy, and power your internal apps!
+
+
+---
+
+## 📋 Final `NOTES.txt` (save as `charts/tooljet/templates/NOTES.txt`)
+
+```txt
+✅ ToolJet has been successfully deployed!
+
+To access ToolJet locally:
+
+1. Forward the service port:
+
+   kubectl port-forward svc/{{ include "tooljet.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+
+2. Then open your browser and navigate to:
+
+   http://localhost:{{ .Values.service.port }}
+
+---
+
+📚 Documentation:
+- ToolJet: https://docs.tooljet.com
+- Helm: https://helm.sh/docs/
+
+🚀 Happy building with ToolJet!

--- a/charts/tooljet/README.md
+++ b/charts/tooljet/README.md
@@ -1,0 +1,61 @@
+# 📦 ToolJet Helm Chart
+
+![ToolJet](https://avatars.githubusercontent.com/u/87657345?s=200&v=4)
+
+This Helm chart deploys **[ToolJet](https://tooljet.com/)** — a modern open-source low-code platform that lets teams build internal tools with ease. You can self-host ToolJet on any Kubernetes cluster using this chart.
+
+---
+
+## 🚀 Features
+
+- ✅ Deploy ToolJet with just one command
+- ⚙️ Customizable environment variables
+- 🌐 Optional ingress support
+- 📈 Scalable with built-in autoscaling settings
+- 🔒 Deploy-ready with service accounts and resource limits
+
+---
+
+## 📦 Installing the Chart
+
+### Prerequisites
+
+- Kubernetes cluster (local or cloud)
+- Helm v3+
+
+### Install ToolJet
+
+```bash
+helm install my-tooljet ./tooljet
+helm uninstall my-tooljet
+
+🛠 Configuration
+You can override default settings by editing values.yaml or using --set:
+
+Parameter	Description	Default
+service.port	Port where ToolJet runs	3000
+env.TOOLJET_HOST	Host address	0.0.0.0
+ingress.enabled	Enable Ingress	false
+autoscaling.enabled	Enable autoscaling	false
+resources	CPU/memory limits	Configurable
+
+📚 References
+ToolJet GitHub
+
+ToolJet Docs
+
+Helm Docs
+
+👨‍💻 Maintainers
+Name	Email
+Madira Mahanandi Reddy	madhirereddy4@gmail.com
+
+Crafted with 💻 and ☁️ by the community. Fork, deploy, and power your internal apps!
+
+yaml
+Copy
+Edit
+
+
+---
+

--- a/charts/tooljet/templates/NOTES.txt
+++ b/charts/tooljet/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "tooljet.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "tooljet.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "tooljet.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "tooljet.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/tooljet/templates/_helpers.tpl
+++ b/charts/tooljet/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tooljet.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tooljet.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tooljet.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tooljet.labels" -}}
+helm.sh/chart: {{ include "tooljet.chart" . }}
+{{ include "tooljet.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tooljet.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tooljet.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "tooljet.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tooljet.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/tooljet/templates/deployment.yaml
+++ b/charts/tooljet/templates/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tooljet.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "tooljet.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tooljet
+  template:
+    metadata:
+      labels:
+        app: tooljet
+    spec:
+      containers:
+        - name: tooljet
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/tooljet/templates/hpa.yaml
+++ b/charts/tooljet/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "tooljet.fullname" . }}
+  labels:
+    {{- include "tooljet.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "tooljet.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/tooljet/templates/ingress.yaml
+++ b/charts/tooljet/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "tooljet.fullname" . }}
+  labels:
+    {{- include "tooljet.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "tooljet.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/tooljet/templates/service.yaml
+++ b/charts/tooljet/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tooljet.fullname" . }}
+  labels:
+    app: tooljet
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: tooljet

--- a/charts/tooljet/templates/serviceaccount.yaml
+++ b/charts/tooljet/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tooljet.serviceAccountName" . }}
+  labels:
+    {{- include "tooljet.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/tooljet/templates/tests/test-connection.yaml
+++ b/charts/tooljet/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "tooljet.fullname" . }}-test-connection"
+  labels:
+    {{- include "tooljet.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "tooljet.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/tooljet/values.yaml
+++ b/charts/tooljet/values.yaml
@@ -1,0 +1,45 @@
+image:
+  repository: tooljet/tooljet
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 3000
+
+env:
+  TOOLJET_HOST: "0.0.0.0"
+  NODE_ENV: "production"
+  DISABLE_SIGNUP: "false"
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 250m
+    memory: 256Mi
+
+serviceAccount:
+  create: true
+  name: ""
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+
+persistence:
+  enabled: false


### PR DESCRIPTION
This PR adds a new Helm chart for deploying [ToolJet](https://tooljet.com/), a modern open-source low-code platform that enables teams to build internal tools quickly.

📦 Chart Highlights:
Deployment: Installs ToolJet on any Kubernetes cluster

Customizable Values: Supports overriding config via values.yaml

Ingress: Optional ingress support for public access

Resources: Configurable CPU/memory limits

Autoscaling: Built-in Horizontal Pod Autoscaler (HPA) configuration

Persistence: Can be toggled via values.yaml