### PR TITLE
feat: add values.schema.json for service and cron-job charts

### DIFF
--- a/charts/cron-job/values.schema.json
+++ b/charts/cron-job/values.schema.json
@@ -33,12 +33,11 @@
       "mutable": true
     },
     "command": {
-      "type": ["array", "string", "null"],
+      "type": ["array", "null"],
       "description": "Command to run in the container",
       "items": {
         "type": "string"
       },
-      "default": "",
       "mutable": true
     },
     "httpPort": {

--- a/charts/cron-job/values.schema.json
+++ b/charts/cron-job/values.schema.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "CronJob Helm Chart Values",
+  "description": "Configuration values for the CronJob Helm chart",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Name of the cron"
+    },
+    "image": {
+      "type": "string",
+      "description": "Docker container image with tag",
+      "mutable": true
+    },
+    "schedule": {
+      "type": "string",
+      "description": "Cron schedule expression",
+      "default": "0 */1 * * *",
+      "mutable": true
+    },
+    "suspend": {
+      "type": "boolean",
+      "description": "Suspend the cron job",
+      "default": false,
+      "mutable": true
+    },
+    "concurrencyPolicy": {
+      "type": "string",
+      "description": "How to treat concurrent executions of the job",
+      "enum": ["Allow", "Forbid", "Replace"],
+      "default": "Replace",
+      "mutable": true
+    },
+    "command": {
+      "type": ["array", "string", "null"],
+      "description": "Command to run in the container",
+      "items": {
+        "type": "string"
+      },
+      "default": "",
+      "mutable": true
+    },
+    "httpPort": {
+      "type": "integer",
+      "description": "Port on which container runs its service",
+      "default": 8000,
+      "mutable": true
+    },
+    "metricsPort": {
+      "type": "integer",
+      "description": "Port on which the container exposes metrics",
+      "default": 2121,
+      "mutable": true
+    },
+    "minCPU": {
+      "type": "string",
+      "description": "CPU request for the container",
+      "pattern": "^[0-9]+m?$",
+      "default": "100m",
+      "mutable": true
+    },
+    "minMemory": {
+      "type": "string",
+      "description": "Memory request for the container",
+      "pattern": "^[0-9]+[KMGTPEZYkmgtpezy]i?$",
+      "default": "128M",
+      "mutable": true
+    },
+    "maxCPU": {
+      "type": "string",
+      "description": "CPU limit for the container",
+      "pattern": "^[0-9]*m?$",
+      "default": "500m",
+      "mutable": true
+    },
+    "maxMemory": {
+      "type": "string",
+      "description": "Memory limit for the container",
+      "pattern": "^([0-9]+[KMGTPEZYkmgtpezy]i?)?$",
+      "default": "512M",
+      "mutable": true
+    },
+    "envFrom": {
+      "type": "object",
+      "description": "Reference environment variables from secrets and configmaps",
+      "properties": {
+        "secrets": {
+          "type": ["array", "null"],
+          "description": "List of secrets to source environment variables from",
+          "items": {
+            "type": "string"
+          },
+          "mutable": true
+        },
+        "configmaps": {
+          "type": ["array", "null"],
+          "description": "List of configmaps to source environment variables from",
+          "items": {
+            "type": "string"
+          },
+          "mutable": true
+        }
+      }
+    },
+    "env": {
+      "type": ["object", "null"],
+      "description": "Environment variables passed as a map",
+      "additionalProperties": {
+        "type": ["string", "number", "boolean"]
+      },
+      "mutable": true
+    },
+    "envList": {
+      "type": ["array", "null"],
+      "description": "Environment variables as a list",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": ["name"]
+      },
+      "mutable": true
+    },
+    "appSecrets": {
+      "type": ["boolean", "string"],
+      "description": "Enable application secrets provisioning via the secrets store CSI driver",
+      "default": false,
+      "mutable": true
+    },
+    "alerts": {
+      "type": "object",
+      "description": "Alerting configuration",
+      "properties": {
+        "standard": {
+          "type": "object",
+          "description": "Standard alerts",
+          "properties": {
+            "infra": {
+              "type": "object",
+              "description": "Infrastructure level alert thresholds",
+              "properties": {
+                "cronjobFailedThreshold": {
+                  "type": "integer",
+                  "description": "Alert if the number of failed cron job runs goes beyond threshold",
+                  "default": 0,
+                  "mutable": true
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": ["name", "image"]
+}

--- a/charts/cron-job/values.schema.json
+++ b/charts/cron-job/values.schema.json
@@ -33,11 +33,16 @@
       "mutable": true
     },
     "command": {
-      "type": ["array", "null"],
-      "description": "Command to run in the container",
+      "type": ["array", "string", "null"],
+      "description": "Command to run in the container. Provide as a list of args. A string is only allowed as the empty unset default (\"\"); a non-empty string renders an invalid manifest because the template emits command via toJson and K8s command is []string.",
       "items": {
         "type": "string"
       },
+      "not": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": "",
       "mutable": true
     },
     "httpPort": {

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -13,7 +13,7 @@ imagePullSecrets:
 schedule: "0 */1 * * *"
 suspend: false
 concurrencyPolicy: "Replace"
-command: []
+command: ""
 
 # Port on which container runs its service
 httpPort: 8000

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -13,7 +13,7 @@ imagePullSecrets:
 schedule: "0 */1 * * *"
 suspend: false
 concurrencyPolicy: "Replace"
-command: ""
+command: []
 
 # Port on which container runs its service
 httpPort: 8000

--- a/charts/service/values.schema.json
+++ b/charts/service/values.schema.json
@@ -243,7 +243,7 @@
       "mutable": true
     },
     "command": {
-      "type": ["array", "string", "null"],
+      "type": ["array", "null"],
       "description": "Command to run in the container",
       "items": {
         "type": "string"

--- a/charts/service/values.schema.json
+++ b/charts/service/values.schema.json
@@ -1,0 +1,377 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Service Helm Chart Values",
+  "description": "Configuration values for the Service Helm chart",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Name of the service"
+    },
+    "image": {
+      "type": "string",
+      "description": "Docker container image with tag",
+      "mutable": true
+    },
+    "httpPort": {
+      "type": "integer",
+      "description": "Port on which container runs its services",
+      "default": 8000,
+      "mutable": true
+    },
+    "metricsPort": {
+      "type": "integer",
+      "description": "Port on which the container exposes metrics. A metrics port is only added when set to a non-zero value.",
+      "mutable": true
+    },
+    "ports": {
+      "type": ["object", "null"],
+      "description": "Additional ports on which the container runs its services, keyed by port name",
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "mutable": true
+    },
+    "nginx": {
+      "type": ["object", "null"],
+      "description": "Ingress (nginx) configuration",
+      "properties": {
+        "host": {
+          "type": ["string", "null"],
+          "description": "Hostname for the ingress",
+          "mutable": true
+        },
+        "annotations": {
+          "type": ["object", "null"],
+          "description": "Annotations to add to the ingress",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "mutable": true
+        },
+        "tlsHost": {
+          "type": ["string", "null"],
+          "description": "Hostname to use for TLS",
+          "mutable": true
+        },
+        "tlsSecretName": {
+          "type": ["string", "null"],
+          "description": "Name of the secret holding the TLS certificate",
+          "mutable": true
+        }
+      }
+    },
+    "envFrom": {
+      "type": "object",
+      "description": "Reference environment variables from secrets and configmaps",
+      "properties": {
+        "secrets": {
+          "type": ["array", "null"],
+          "description": "List of secrets to source environment variables from",
+          "items": {
+            "type": "string"
+          },
+          "mutable": true
+        },
+        "configmaps": {
+          "type": ["array", "null"],
+          "description": "List of configmaps to source environment variables from",
+          "items": {
+            "type": "string"
+          },
+          "mutable": true
+        }
+      }
+    },
+    "minCPU": {
+      "type": "string",
+      "description": "CPU request for the container",
+      "pattern": "^[0-9]+m?$",
+      "default": "100m",
+      "mutable": true
+    },
+    "minMemory": {
+      "type": "string",
+      "description": "Memory request for the container",
+      "pattern": "^[0-9]+[KMGTPEZYkmgtpezy]i?$",
+      "default": "128M",
+      "mutable": true
+    },
+    "maxCPU": {
+      "type": "string",
+      "description": "CPU limit for the container",
+      "pattern": "^[0-9]*m?$",
+      "default": "500m",
+      "mutable": true
+    },
+    "maxMemory": {
+      "type": "string",
+      "description": "Memory limit for the container",
+      "pattern": "^([0-9]+[KMGTPEZYkmgtpezy]i?)?$",
+      "default": "512M",
+      "mutable": true
+    },
+    "minReplicas": {
+      "type": "integer",
+      "description": "Minimum number of replicas for autoscaling",
+      "minimum": 0,
+      "default": 2,
+      "mutable": true
+    },
+    "maxReplicas": {
+      "type": "integer",
+      "description": "Maximum number of replicas for autoscaling",
+      "minimum": 1,
+      "default": 4,
+      "mutable": true
+    },
+    "hpa_enable": {
+      "type": "boolean",
+      "description": "Enable the native HorizontalPodAutoscaler. Ignored when keda.enabled is true.",
+      "default": false,
+      "mutable": true
+    },
+    "hpaCPU": {
+      "type": ["string", "null"],
+      "description": "Target average CPU utilization percentage for the HPA. When empty, it is derived from minCPU and maxCPU.",
+      "mutable": true
+    },
+    "hpaMemory": {
+      "type": ["string", "null"],
+      "description": "Target average memory utilization percentage for the HPA. When empty, it is derived from minMemory and maxMemory.",
+      "mutable": true
+    },
+    "heartbeatURL": {
+      "type": "string",
+      "description": "Heartbeat URL used for readiness and liveness probes",
+      "default": "",
+      "mutable": true
+    },
+    "readinessProbe": {
+      "type": "object",
+      "description": "Readiness probe configuration",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "description": "Enable the readiness probe",
+          "default": false,
+          "mutable": true
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "description": "Delay before the first probe",
+          "mutable": true
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "Timeout for each probe",
+          "mutable": true
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "description": "How often to perform the probe",
+          "mutable": true
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "description": "Number of failures before marking unready",
+          "mutable": true
+        }
+      }
+    },
+    "livenessProbe": {
+      "type": "object",
+      "description": "Liveness probe configuration",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "description": "Enable the liveness probe",
+          "default": false,
+          "mutable": true
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "description": "Delay before the first probe",
+          "mutable": true
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "Timeout for each probe",
+          "mutable": true
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "description": "How often to perform the probe",
+          "mutable": true
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "description": "Number of failures before restarting the container",
+          "mutable": true
+        }
+      }
+    },
+    "env": {
+      "type": ["object", "null"],
+      "description": "Environment variables passed as a map",
+      "additionalProperties": {
+        "type": ["string", "number", "boolean"]
+      },
+      "mutable": true
+    },
+    "envList": {
+      "type": ["array", "null"],
+      "description": "Environment variables as a list",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": ["string", "number", "boolean"]
+          }
+        },
+        "required": ["name"]
+      },
+      "mutable": true
+    },
+    "appSecrets": {
+      "type": ["boolean", "string"],
+      "description": "Enable application secrets provisioning via the secrets store CSI driver",
+      "default": false,
+      "mutable": true
+    },
+    "command": {
+      "type": ["array", "string", "null"],
+      "description": "Command to run in the container",
+      "items": {
+        "type": "string"
+      },
+      "mutable": true
+    },
+    "alerts": {
+      "type": "object",
+      "description": "Alerting configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Set to false to skip creating the PrometheusRule for this service",
+          "default": true,
+          "mutable": true
+        },
+        "standard": {
+          "type": "object",
+          "description": "Standard alerts",
+          "properties": {
+            "infra": {
+              "type": "object",
+              "description": "Infrastructure level alert thresholds",
+              "properties": {
+                "unavailableReplicasThreshold": {
+                  "type": "integer",
+                  "description": "Alert if the available replicas is lesser than number of desired replicas",
+                  "default": 0,
+                  "mutable": true
+                },
+                "podRestartThreshold": {
+                  "type": "integer",
+                  "description": "Alert if the pod restarts goes beyond threshold over the time window",
+                  "default": 0,
+                  "mutable": true
+                },
+                "podRestartTimeWindow": {
+                  "type": "string",
+                  "description": "Time window for pod restart alert",
+                  "default": "5m",
+                  "mutable": true
+                },
+                "hpaNearingMaxPodThreshold": {
+                  "type": "integer",
+                  "description": "Alert if replica count crosses the threshold percentage of max pod count",
+                  "default": 80,
+                  "mutable": true
+                },
+                "serviceMemoryUtilizationThreshold": {
+                  "type": "integer",
+                  "description": "Alert if service memory exceeds threshold",
+                  "default": 90,
+                  "mutable": true
+                },
+                "serviceCpuUtilizationThreshold": {
+                  "type": "integer",
+                  "description": "Alert if service cpu exceeds threshold",
+                  "default": 90,
+                  "mutable": true
+                },
+                "serviceCpuUtilizationTimeWindow": {
+                  "type": "string",
+                  "description": "Time window for service cpu utilization",
+                  "default": "5m",
+                  "mutable": true
+                },
+                "healthCheckFailureThreshold": {
+                  "type": "integer",
+                  "description": "Alert if application health-check failures goes beyond threshold in the time window",
+                  "default": 50,
+                  "mutable": true
+                },
+                "healthCheckFailureTimeWindow": {
+                  "type": "string",
+                  "description": "Time window for health-check failure alert",
+                  "default": "5m",
+                  "mutable": true
+                }
+              }
+            }
+          }
+        },
+        "custom": {
+          "type": ["array", "null"],
+          "description": "Custom alert definitions",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "alertRule": {
+                "type": "string"
+              },
+              "sumByLabel": {
+                "type": "string"
+              },
+              "percentile": {
+                "type": "number"
+              },
+              "labelValue": {
+                "type": "string"
+              },
+              "queryOperator": {
+                "type": "string"
+              },
+              "timeWindow": {
+                "type": "string"
+              },
+              "threshold": {
+                "type": "number"
+              },
+              "labels": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["name", "alertRule", "threshold"]
+          },
+          "mutable": true
+        }
+      }
+    }
+  },
+  "required": ["name", "image"]
+}


### PR DESCRIPTION
## Summary

Adds `values.schema.json` (JSON Schema draft-07) for the **service** and **cron-job** charts, following the format used by the existing charts in this repo (e.g. `mariadb`). These schemas drive the editable form fields rendered by the form manager, which fetches `charts/<name>/values.schema.json` directly from the `main` branch (no chart release/version bump required).

Two commits, one per file:
- `feat(service): add values.schema.json for service chart`
- `feat(cron-job): add values.schema.json for cron-job chart`

## Scope of fields

The schemas describe only the **user-configurable** values surfaced in the UI. Each editable field is annotated with `"mutable": true` (a real boolean), and `name` is intentionally left non-mutable.

- **service:** `name`, `image`, `httpPort`, `metricsPort`, `ports`, `nginx`, `envFrom`, `minCPU/minMemory/maxCPU/maxMemory`, `minReplicas/maxReplicas`, `hpa_enable/hpaCPU/hpaMemory`, `heartbeatURL`, `readinessProbe`, `livenessProbe`, `env`, `envList`, `appSecrets`, `command`, `alerts`
- **cron-job:** `name`, `image`, `schedule`, `suspend`, `concurrencyPolicy`, `command`, `httpPort`, `metricsPort`, `minCPU/minMemory/maxCPU/maxMemory`, `envFrom`, `env`, `envList`, `appSecrets`, `alerts`

Advanced/internal keys (`keda`, `securityContext`, `initContainer`, `datastores`, `imagePullSecrets`, `volumeMounts`, etc.) are intentionally omitted. Since neither schema sets `additionalProperties: false`, those keys remain fully valid and functional — they are simply not schema-validated or rendered as form fields.

## Notes on typing

- Keys that default to `null` in `values.yaml` accept `"null"` in their type so the shipped defaults pass Helm validation.
- `hpaCPU`/`hpaMemory` are typed as `string|null` (the `hpa.yaml` template compares them to `""` and `nil`, so an integer breaks rendering).
- CPU/memory use `pattern` regexes consistent with the `mariadb` schema.
- Top-level `required: ["name", "image"]`; nested `required` arrays are scoped to their objects and only fire when those optional sections are populated.

## Verification

- Both files are valid JSON
- `helm lint` passes for both charts
- `helm template` renders both with default `values.yaml`
- `helm template` renders both with **every** schema field set to a realistic value, and the values flow through to the manifests (Deployment/HPA/Ingress/PrometheusRule for service; CronJob/PrometheusRule for cron-job)
- Negative cases rejected as expected (bad `serviceType`/`concurrencyPolicy` enums, missing required fields)
