### PR TITLE
feat(charts): add UI settings category to all chart schemas (+ redis mutable fix)

### DIFF
--- a/charts/cassandra/values.schema.json
+++ b/charts/cassandra/values.schema.json
@@ -3,6 +3,7 @@
     "type": "object",
     "properties": {
       "resources": {
+        "category": "compute",
         "type": "object",
         "properties": {
           "requests": {
@@ -34,11 +35,13 @@
         }
       },
       "diskSize": {
+        "category": "compute",
         "type": "string",
         "default": "10Gi", "mutable": true,
         "editDisabled": true
       },
       "services": {
+        "category": "runtime",
         "type": "array",
         "items": {
           "type": "object",

--- a/charts/chromadb/values.schema.json
+++ b/charts/chromadb/values.schema.json
@@ -7,6 +7,7 @@
       "default": "ghcr.io/chroma-core/chroma:latest"
     },
     "resources": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "requests": {
@@ -46,6 +47,7 @@
       }
     },
     "diskSize": {
+      "category": "compute",
       "type": "string",
       "pattern": "^[0-9]+Gi$",
       "default": "10Gi",
@@ -53,6 +55,7 @@
       "editDisabled": true
     },
     "services": {
+      "category": "runtime",
       "type": "array",
       "items": {
         "type": "object",

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -3,22 +3,26 @@
   "type": "object",
   "properties": {
     "diskSize": {
+      "category": "compute",
       "type": "string",
       "default": "10Gi",
       "mutable": true,
       "editDisabled": true
     },
     "customConfig": {
+      "category": "advanced",
       "type": "string",
       "default": "",
       "mutable": true
     },
     "version": {
+      "category": "runtime",
       "type": "string",
       "default": "25.3",
       "mutable": true
     },
     "resources": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "requests": {
@@ -54,6 +58,7 @@
       }
     },
     "services": {
+      "category": "runtime",
       "type": "array",
       "items": {
         "type": "object",

--- a/charts/cockroachdb/values.schema.json
+++ b/charts/cockroachdb/values.schema.json
@@ -3,6 +3,7 @@
     "type": "object",
     "properties": {
       "resources": {
+        "category": "compute",
         "type": "object",
         "properties": {
           "requests": {
@@ -34,15 +35,18 @@
         }
       },
       "diskSize": {
+        "category": "compute",
         "type": "string",
         "default": "10Gi", "mutable": true,
         "editDisabled": true
       },
       "version": {
+        "category": "runtime",
       "default": "v25.1.2",
       "mutable": true
     },
       "services": {
+        "category": "runtime",
         "type": "array",
         "items": {
           "type": "object",

--- a/charts/dgraph/values.schema.json
+++ b/charts/dgraph/values.schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "properties": {
     "services": {
+      "category": "runtime",
         "type": "array",
         "items": {
           "type": "object",
@@ -15,6 +16,7 @@
         }
       },
     "zero": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "resources": {
@@ -48,6 +50,7 @@
       "required": ["resources", "diskSize"]
     },
     "alpha": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "resources": {

--- a/charts/jupyterhub/values.schema.json
+++ b/charts/jupyterhub/values.schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "properties": {
     "hub": {
+      "category": "advanced",
       "type": "object",
       "properties": {
         "config": {
@@ -21,6 +22,7 @@
       }
     },
     "proxy": {
+      "category": "advanced",
       "type": "object",
       "properties": {
         "https": {
@@ -47,6 +49,7 @@
       }
     },
     "singleuser": {
+      "category": "runtime",
       "type": "object",
       "properties": {
         "networkTools": {
@@ -128,6 +131,7 @@
       }
     },
     "scheduling": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "userScheduler": {
@@ -141,6 +145,7 @@
       }
     },
     "prePuller": {
+      "category": "advanced",
       "type": "object",
       "properties": {
         "hook": {
@@ -159,6 +164,7 @@
       }
     },
     "cull": {
+      "category": "advanced",
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean", "enum": [true] },

--- a/charts/kafka/values.schema.json
+++ b/charts/kafka/values.schema.json
@@ -3,11 +3,13 @@
   "type": "object",
   "properties": {
     "version": {
+      "category": "runtime",
       "type": "string",
       "default": "7.8.0",
       "mutable": true
     },
     "zookeeper": {
+      "category": "advanced",
       "type": "object",
       "properties": {
         "enabled": {
@@ -21,6 +23,7 @@
       }
     },
     "resources": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "requests": {
@@ -60,6 +63,7 @@
       }
     },
     "diskSize": {
+      "category": "compute",
       "type": "string",
       "pattern": "^[0-9]+Gi$",
       "default": "10Gi",
@@ -67,6 +71,7 @@
       "editDisabled": true
     },
     "services": {
+      "category": "runtime",
         "type": "array",
         "items": {
           "type": "object",

--- a/charts/mariadb/values.schema.json
+++ b/charts/mariadb/values.schema.json
@@ -5,12 +5,14 @@
   "description": "Configuration values for MariaDB Helm chart",
   "properties": {
     "version": {
+      "category": "runtime",
       "type": "string",
       "description": "MariaDB version to deploy",
       "default": "10.3.22-debian-10-r27",
       "mutable": true
     },
     "replication": {
+      "category": "compute",
       "type": "object",
       "description": "Replication configuration",
       "properties": {
@@ -23,6 +25,7 @@
       }
     },
     "master": {
+      "category": "compute",
       "type": "object",
       "description": "Master node configuration",
       "properties": {
@@ -89,6 +92,7 @@
       }
     },
     "slave": {
+      "category": "compute",
       "type": "object",
       "description": "Slave node configuration",
       "properties": {

--- a/charts/mosquitto/values.schema.json
+++ b/charts/mosquitto/values.schema.json
@@ -3,14 +3,17 @@
   "type": "object",
   "properties": {
     "version": {
+      "category": "runtime",
       "type": "string",
       "mutable": true
     },
     "disk_size": {
+      "category": "compute",
       "type": "string",
       "mutable": true
     },
     "auth": {
+      "category": "environment",
       "type": "object",
       "properties": {
         "enabled": {
@@ -32,6 +35,7 @@
       }
     },
     "tls": {
+      "category": "advanced",
       "type": "object",
       "properties": {
         "enabled": {
@@ -45,6 +49,7 @@
       }
     },
     "service": {
+      "category": "runtime",
       "type": "object",
       "properties": {
         "type": {
@@ -54,6 +59,7 @@
       }
     },
     "resources": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "limits": {

--- a/charts/mysql/values.schema.json
+++ b/charts/mysql/values.schema.json
@@ -3,21 +3,25 @@
   "type": "object",
   "properties": {
     "diskSize": {
+      "category": "compute",
       "type": "string",
       "default": "10Gi",
       "mutable": true,
       "editDisabled": true
     },
     "customMyCnf": {
+      "category": "advanced",
       "type": "string",
       "default": "",
       "mutable": true
     },
     "version": {
+      "category": "runtime",
       "default": "8.0",
       "mutable": true
     },
     "resources": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "requests": {
@@ -53,6 +57,7 @@
       }
     },
     "services": {
+      "category": "runtime",
       "type": "array",
       "items": {
         "type": "object",

--- a/charts/opentsdb/values.schema.json
+++ b/charts/opentsdb/values.schema.json
@@ -3,11 +3,13 @@
   "type": "object",
   "properties": {
     "version": {
+      "category": "runtime",
       "type": "string",
       "default": "v0.0.1",
       "mutable": true
     },
     "resources": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "requests": {
@@ -47,6 +49,7 @@
       }
     },
     "diskSize": {
+      "category": "compute",
       "type": "string",
       "pattern": "^[0-9]+Gi$",
       "default": "10Gi",
@@ -54,6 +57,7 @@
       "editDisabled": true
     },
     "services": {
+      "category": "runtime",
       "type": "array",
       "items": {
         "type": "object",

--- a/charts/outline/values.schema.json
+++ b/charts/outline/values.schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "properties": {
     "postgres": {
+      "category": "advanced",
       "type": "object",
       "properties": {
         "services": {
@@ -18,6 +19,7 @@
       }
     },
     "redis": {
+      "category": "advanced",
       "type": "object",
       "properties": {
         "services": {
@@ -33,6 +35,7 @@
       }
     },
     "service": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "name": { "type": "string", "enum": ["outline"] },

--- a/charts/postgres/values.schema.json
+++ b/charts/postgres/values.schema.json
@@ -3,11 +3,13 @@
   "type": "object",
   "properties": {
     "version": {
+      "category": "runtime",
       "type": "string",
       "default": "17.4.0",
       "mutable": true
     },
     "replication": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "enabled": {
@@ -24,12 +26,14 @@
       "required": ["enabled", "count"]
     },
     "diskSize": {
+      "category": "compute",
       "type": "string",
       "default": "10Gi",
       "mutable": true,
       "editDisabled": true
     },
     "resources": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "requests": {
@@ -68,6 +72,7 @@
       "required": ["requests", "limits"]
     },
     "services": {
+      "category": "runtime",
       "type": "array",
       "items": {
         "type": "object",

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "properties": {
     "services": {
+      "category": "runtime",
         "type": "array",
         "items": {
           "type": "object",
@@ -15,6 +16,7 @@
         }
       },
     "diskSize": {
+      "category": "compute",
       "type": "string",
       "pattern": "^[0-9]+Gi$",
       "default": "10Gi",
@@ -22,9 +24,11 @@
       "editDisabled": true
     },
     "version": {
+      "category": "runtime",
       "type": "string"
     },
     "resources": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "requests": {

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -34,16 +34,16 @@
         "requests": {
           "type": "object",
           "properties": {
-            "cpu": { "type": "string" , "pattern": "^[0-9]+m$", "default": "500m",  "mutable": "true"},
-            "memory": { "type": "string" , "pattern": "^[0-9]+M$", "default": "256M",  "mutable": "true"}
+            "cpu": { "type": "string" , "pattern": "^[0-9]+m$", "default": "500m",  "mutable": true},
+            "memory": { "type": "string" , "pattern": "^[0-9]+M$", "default": "256M",  "mutable": true}
           },
           "required": ["cpu", "memory"]
         },
         "limits": {
           "type": "object",
           "properties": {
-            "cpu": { "type": "string" , "pattern": "^[0-9]+m$", "default": "1500m", "mutable": "true"},
-            "memory": { "type": "string", "pattern": "^[0-9]+Gi$", "default": "1024M", "mutable": "true"}
+            "cpu": { "type": "string" , "pattern": "^[0-9]+m$", "default": "1500m", "mutable": true},
+            "memory": { "type": "string", "pattern": "^[0-9]+Gi$", "default": "1024M", "mutable": true}
           },
           "required": ["cpu", "memory"]
         }

--- a/charts/redisdistributed/values.schema.json
+++ b/charts/redisdistributed/values.schema.json
@@ -3,10 +3,12 @@
   "type": "object",
   "properties": {
     "version": {
+      "category": "runtime",
       "type": "string",
       "default": "6.2.13"
     },
     "services": {
+      "category": "runtime",
       "type": "array",
       "items": {
         "type": "object",
@@ -19,6 +21,7 @@
       }
     },
     "master": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "resources": {
@@ -75,6 +78,7 @@
       "required": ["resources", "persistence"]
     },
     "slave": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "enable": {

--- a/charts/solr/values.schema.json
+++ b/charts/solr/values.schema.json
@@ -3,10 +3,12 @@
   "type": "object",
   "properties": {
     "version": {
+      "category": "runtime",
       "default": "9.8",
       "mutable": true
     },
     "resources": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "requests": {
@@ -38,11 +40,13 @@
       }
     },
     "diskSize": {
+      "category": "compute",
       "type": "string",
       "default": "10Gi", "mutable": true,
       "editDisabled": true
     },
     "services": {
+      "category": "runtime",
       "type": "array",
       "items": {
         "type": "object",

--- a/charts/solrcloud/values.schema.json
+++ b/charts/solrcloud/values.schema.json
@@ -3,11 +3,13 @@
   "type": "object",
   "properties": {
     "version": {
+      "category": "runtime",
       "type": "string",
       "default": "8.11",
       "mutable": true
     },
     "resources": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "requests": {
@@ -43,12 +45,14 @@
       }
     },
     "diskSize": {
+      "category": "compute",
       "type": "string",
       "default": "20Gi",
       "mutable": true,
       "editDisabled": true
     },
     "solr-operator": {
+      "category": "advanced",
       "type": "object",
       "properties": {
         "version": {
@@ -94,6 +98,7 @@
       }
     },
     "services": {
+      "category": "runtime",
       "type": "array",
       "items": {
         "type": "object",

--- a/charts/superset/values.schema.json
+++ b/charts/superset/values.schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "properties": {
     "resources": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "requests": {
@@ -22,6 +23,7 @@
       }
     },
     "supersetNode": {
+      "category": "environment",
       "type": "object",
       "properties": {
         "connections": {
@@ -49,6 +51,7 @@
       }
     },
     "init": {
+      "category": "advanced",
       "type": "object",
       "properties": {
         "createAdmin": { "type": "boolean", "enum": [true] },
@@ -66,6 +69,7 @@
       }
     },
     "postgres": {
+      "category": "advanced",
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean", "enum": [true] },
@@ -84,6 +88,7 @@
       }
     },
     "redis": {
+      "category": "advanced",
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean", "enum": [true] }

--- a/charts/surrealdb/values.schema.json
+++ b/charts/surrealdb/values.schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "properties": {
     "version": {
+      "category": "runtime",
       "type": "string",
       "default": "v2",
       "mutable": true,
@@ -10,6 +11,7 @@
       
     },
     "resources": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "requests": {
@@ -53,6 +55,7 @@
       }
     },
     "diskSize": {
+      "category": "compute",
       "type": "string",
       "pattern": "^[0-9]+Gi$",
       "default": "10Gi",
@@ -61,6 +64,7 @@
       "editDisabled": true
     },
     "services": {
+      "category": "runtime",
         "type": "array",
         "items": {
           "type": "object",

--- a/charts/uptime-monitoring/values.schema.json
+++ b/charts/uptime-monitoring/values.schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "properties": {
     "blackbox": {
+      "category": "runtime",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -25,6 +26,7 @@
     },
 
     "prometheus": {
+      "category": "advanced",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -52,6 +54,7 @@
     },
 
     "targets": {
+      "category": "advanced",
       "type": "array",
       "description": "List of HTTP/HTTPS targets for Blackbox monitoring",
       "default": [],

--- a/charts/wordpress/values.schema.json
+++ b/charts/wordpress/values.schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "properties": {
     "mysql": {
+      "category": "advanced",
       "type": "object",
       "properties": {
         "services": {
@@ -19,6 +20,7 @@
       }
     },
     "service": {
+      "category": "compute",
       "type": "object",
       "properties": {
         "name": { "type": "string", "enum": ["wordpress"] },


### PR DESCRIPTION
## What

Adds the UI settings `category` key to every chart schema that has a `values.schema.json` but wasn't yet categorised, using the fixed vocabulary the ZopDay imported-service Settings UI standardises on: **`runtime` · `compute` · `environment` · `advanced`**. Also fixes a `mutable` typo in the redis schema.

`service` and `cron-job` already carry these categories (merged earlier); this covers the remaining 21 charts.

## Why

helm-manager reads `category` off each top-level property and the ZopDay Settings drawer groups fields into tabs by it. Without a category, a chart's fields don't surface in the tabbed Settings view. This is **UI-only metadata** — `category` is a non-standard JSON-Schema keyword that Helm ignores at install time, so **no repackaging or `Chart.yaml` bump is needed** (helm-manager reads the schema from the branch/main source, not the packaged `.tgz`).

## Mapping (top-level properties)

- **compute** — `resources`, `diskSize`/`disk_size`, `replication`, per-component resource objects (`master`, `slave`, `zero`, `alpha`), scheduling
- **runtime** — `version`, `services`/`service`, ports
- **environment** — `auth`, `supersetNode` (db/redis connections)
- **advanced** — `customConfig`/`customMyCnf`, `tls`, `zookeeper`, `solr-operator`, bundled dependencies (`postgres`/`redis`/`mysql`), `init`, jupyterhub `hub`/`proxy`/`prePuller`/`cull`, uptime `prometheus`/`targets`
- `image`/`name` left uncategorised (hidden from settings, same as `service`)

## redis `mutable` fix

The four `resources.{requests,limits}.{cpu,memory}` fields had `"mutable": "true"` (a quoted **string**). helm-manager asserts `props["mutable"].(bool)`, which fails on a string, so those fields were never emitted and redis resources didn't render. Changed to boolean `true`.

## Notes

- 87 additive category insertions across 21 charts + 4 redis boolean fixes; no existing lines removed.
- All schemas validated as well-formed JSON; every category value is one of the four allowed.
