### PR TITLE
feat(images): add scale-to-zero image

### DIFF
--- a/images/scale-to-zero/Dockerfile
+++ b/images/scale-to-zero/Dockerfile
@@ -1,0 +1,85 @@
+# -------------------------------
+# Caddy + Sablier scale-to-zero plugin
+# -------------------------------
+# WHY THIS IMAGE EXISTS:
+# The Sablier wake-on-request plugin is a Caddy MODULE. Caddy modules are
+# compiled INTO the binary with xcaddy — they cannot be dropped into a
+# stock Caddy at runtime — and upstream publishes no prebuilt
+# "Caddy + Sablier" binary. So we build our own.
+#
+# WHY THIS LINK:
+# https://github.com/sablierapp/sablier-caddy-plugin
+# https://github.com/caddyserver/xcaddy
+#
+# THIS IMAGE IS A CARRIER, NOT A RUNTIME:
+# ZopDay VM pools run Caddy as a host systemd service (it binds :80/:443
+# and reads /etc/caddy), so nothing runs this container. The VM's
+# scale-to-zero component pulls the image and copies the binary out:
+#
+#   docker create --name caddy-x zopdev/scale-to-zero:v<version>
+#   docker cp caddy-x:/usr/bin/caddy /tmp/caddy && docker rm caddy-x
+#
+# Docker Hub is used rather than a release asset because Docker is already
+# a baseline component on every pool VM and those VMs already pull public
+# images — no new registry auth or network path.
+
+
+# -------------------------------
+# Version pinning (CRITICAL)
+# -------------------------------
+# CADDY_VERSION MUST stay in lockstep with the version the ZopDay deployer's
+# baseline `caddy` component installs (backend/deployer/configs/
+# vm-components.yaml). Both variants report the SAME version string and
+# differ only by the extra dormant module, which is exactly what lets the
+# component's skip-download gate treat them as interchangeable. Bumping
+# this without bumping the deployer (or vice versa) makes every prep
+# re-download the binary forever.
+#
+# SABLIER_PLUGIN_VERSION is pinned so a rebuild is reproducible; the plugin
+# is inert until a `sablier` directive appears in the Caddyfile, so this
+# binary is a safe drop-in replacement for stock Caddy.
+ARG CADDY_VERSION=2.11.3
+ARG SABLIER_PLUGIN_VERSION=v1.0.2
+
+
+# -------------------------------
+# Build stage
+# -------------------------------
+# The official caddy:<version>-builder image ships xcaddy and the Go
+# toolchain, so the build needs no extra dependencies.
+FROM caddy:${CADDY_VERSION}-builder AS builder
+
+ARG SABLIER_PLUGIN_VERSION
+RUN xcaddy build \
+    --with github.com/sablierapp/sablier-caddy-plugin@${SABLIER_PLUGIN_VERSION}
+
+
+# -------------------------------
+# Build-time assertions (CRITICAL)
+# -------------------------------
+# Fail the BUILD rather than a VM install six steps later. Two invariants
+# the deployer depends on:
+#
+#   1. the exact version string its skip-download gate matches
+#      (`caddy version | grep "^v<version> "`), and
+#   2. the module id its precondition check greps for
+#      (`caddy list-modules | grep '^http.handlers.sablier'`).
+#
+# Both were verified against a real build before this image was written; a
+# plugin or Caddy bump that breaks either one stops here.
+ARG CADDY_VERSION
+RUN /usr/bin/caddy version | grep -q "^v${CADDY_VERSION} " \
+      || { echo "version mismatch: $(/usr/bin/caddy version)" >&2; exit 1; } \
+ && /usr/bin/caddy list-modules | grep -q '^http.handlers.sablier' \
+      || { echo "sablier module missing from build" >&2; /usr/bin/caddy list-modules >&2; exit 1; }
+
+
+# -------------------------------
+# Final image
+# -------------------------------
+# Based on the official caddy:<version> image so the binary sits at the
+# conventional /usr/bin/caddy path the copy-out step above expects, and so
+# the image is still a usable Caddy if anyone does run it directly.
+FROM caddy:${CADDY_VERSION}
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/images/scale-to-zero/Dockerfile
+++ b/images/scale-to-zero/Dockerfile
@@ -16,7 +16,7 @@
 # and reads /etc/caddy), so nothing runs this container. The VM's
 # scale-to-zero component pulls the image and copies the binary out:
 #
-#   CID=$(docker create zopdev/scale-to-zero:v<version>)
+#   CID=$(docker create zopdev/scale-to-zero:v0.0.1)
 #   docker cp "$CID:/usr/bin/caddy" /tmp/caddy && docker rm "$CID"
 #
 # Docker Hub is used rather than a release asset because Docker is already

--- a/images/scale-to-zero/Dockerfile
+++ b/images/scale-to-zero/Dockerfile
@@ -16,8 +16,8 @@
 # and reads /etc/caddy), so nothing runs this container. The VM's
 # scale-to-zero component pulls the image and copies the binary out:
 #
-#   docker create --name caddy-x zopdev/scale-to-zero:v<version>
-#   docker cp caddy-x:/usr/bin/caddy /tmp/caddy && docker rm caddy-x
+#   CID=$(docker create zopdev/scale-to-zero:v<version>)
+#   docker cp "$CID:/usr/bin/caddy" /tmp/caddy && docker rm "$CID"
 #
 # Docker Hub is used rather than a release asset because Docker is already
 # a baseline component on every pool VM and those VMs already pull public
@@ -49,8 +49,16 @@ ARG SABLIER_PLUGIN_VERSION=v1.0.2
 # toolchain, so the build needs no extra dependencies.
 FROM caddy:${CADDY_VERSION}-builder AS builder
 
+ARG CADDY_VERSION
 ARG SABLIER_PLUGIN_VERSION
-RUN xcaddy build \
+
+# The Caddy version is passed EXPLICITLY rather than inherited. The builder
+# image sets `ENV CADDY_VERSION=v2.11.3` (with a "v") and a bare `xcaddy build`
+# would silently use it — while the assertion below needs the un-prefixed ARG
+# for its `^v${CADDY_VERSION}` grep. Relying on that difference would make the
+# build depend on where the ARG line sits relative to this one, so both values
+# are derived from one source here instead.
+RUN xcaddy build "v${CADDY_VERSION}" \
     --with github.com/sablierapp/sablier-caddy-plugin@${SABLIER_PLUGIN_VERSION}
 
 
@@ -67,7 +75,6 @@ RUN xcaddy build \
 #
 # Both were verified against a real build before this image was written; a
 # plugin or Caddy bump that breaks either one stops here.
-ARG CADDY_VERSION
 RUN /usr/bin/caddy version | grep -q "^v${CADDY_VERSION} " \
       || { echo "version mismatch: $(/usr/bin/caddy version)" >&2; exit 1; } \
  && /usr/bin/caddy list-modules | grep -q '^http.handlers.sablier' \
@@ -83,3 +90,13 @@ RUN /usr/bin/caddy version | grep -q "^v${CADDY_VERSION} " \
 FROM caddy:${CADDY_VERSION}
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+
+# -------------------------------
+# Ship-stage assertion
+# -------------------------------
+# The checks above run in the builder; this one runs on the image that is
+# actually published, so a wrong COPY path or a base-tag/builder-tag mismatch
+# cannot slip through.
+ARG CADDY_VERSION
+RUN caddy version | grep -q "^v${CADDY_VERSION} " \
+ && caddy list-modules | grep -q '^http.handlers.sablier'

--- a/images/scale-to-zero/README.md
+++ b/images/scale-to-zero/README.md
@@ -1,0 +1,136 @@
+# scale-to-zero Docker Image
+
+The scale-to-zero Docker image packages the [Caddy](https://caddyserver.com) web server with the [Sablier](https://sablierapp.dev) scale-to-zero plugin compiled in.
+
+> **What this image is — and is not.** It is named for the capability it enables, but it contains *only the Caddy half*: the request-interception plugin. The scale-to-zero orchestrator itself is upstream's own `sablierapp/sablier` image, pulled separately at runtime and not rebuilt here. So this image alone does not provide scale-to-zero — it provides the Caddy binary that can talk to the thing that does. Sablier's wake-on-request plugin is a Caddy **module**: it must be built into the binary with `xcaddy` and cannot be loaded into a stock Caddy at runtime, and upstream ships no prebuilt "Caddy + Sablier" binary — hence this image.
+
+The image is a **carrier, not a runtime**. ZopDay VM pools run Caddy as a host systemd service (binding `:80`/`:443` and reading `/etc/caddy`), so nothing runs this container in production: the VM's `scale-to-zero` component pulls it and copies the binary out. Docker Hub is used rather than a release asset because Docker is already a baseline component on every pool VM and those VMs already pull public images — no new registry auth or network path.
+
+---
+
+## Components & Versions
+
+| Component              | Version   | Description                                                            |
+|------------------------|-----------|------------------------------------------------------------------------|
+| Caddy                  | 2.11.3    | Base web server / reverse proxy. Must match the deployer's baseline    |
+| sablier-caddy-plugin   | v1.0.2    | Wake-on-request middleware, compiled in via xcaddy                     |
+| xcaddy                 | bundled   | Supplied by the official `caddy:<version>-builder` image               |
+
+> **Version lockstep (critical).** `CADDY_VERSION` must match the version the ZopDay deployer's baseline `caddy` component installs (`backend/deployer/configs/vm-components.yaml`). Both variants report the *same* version string and differ only by the extra dormant module — that is precisely what lets the component's skip-download gate treat them as interchangeable. Bumping one without the other makes every prep re-download the binary forever.
+
+---
+
+## Prerequisites
+
+- Docker 20.10+
+
+---
+
+## Build Image
+
+To build the Docker image, run the following command from the repository root:
+
+```bash
+docker build -f images/scale-to-zero/Dockerfile -t scale-to-zero:latest images/
+```
+
+Override the pinned versions at build time if needed:
+
+```bash
+docker build -f images/scale-to-zero/Dockerfile \
+  --build-arg CADDY_VERSION=2.11.3 \
+  --build-arg SABLIER_PLUGIN_VERSION=v1.0.2 \
+  -t scale-to-zero:latest images/
+```
+
+The build fails fast if either invariant the deployer relies on is broken — the exact version string, or the presence of the `http.handlers.sablier` module.
+
+---
+
+## Verify
+
+```bash
+docker run --rm scale-to-zero:latest caddy version
+# v2.11.3 h1:...
+
+docker run --rm scale-to-zero:latest caddy list-modules | grep sablier
+# http.handlers.sablier
+```
+
+The plugin is **inert** unless a `sablier` directive appears in the Caddyfile, so this binary is a drop-in replacement for stock Caddy of the same version.
+
+---
+
+## Usage
+
+The consumer is the ZopDay deployer's `scale-to-zero` VM component, which copies the binary onto the VM rather than running the container:
+
+```bash
+docker pull zopdev/scale-to-zero:v2.11.3
+CID=$(docker create zopdev/scale-to-zero:v2.11.3)
+docker cp "$CID:/usr/bin/caddy" /tmp/caddy
+docker rm "$CID"
+# validated against the live Caddyfile, then installed to /usr/local/bin/caddy
+```
+
+The component validates the downloaded binary with `caddy validate --config /etc/caddy/Caddyfile` **before** replacing the live one (Caddy is the VM's only ingress) and keeps the previous binary at `/usr/local/bin/caddy.prev` for rollback.
+
+---
+
+## File Structure
+
+```
+images/scale-to-zero/
+├── Dockerfile   # two-stage: xcaddy build + assertions, then the final carrier image
+└── README.md
+```
+
+---
+
+## Features
+
+- Caddy with the Sablier wake-on-request module compiled in
+- Version-pinned Caddy and plugin for reproducible builds
+- Build-time assertions on both invariants the deployer depends on
+- Plugin inert without a `sablier` directive — safe drop-in for stock Caddy
+- Binary at the conventional `/usr/bin/caddy` path
+
+---
+
+## Publish
+
+The image is published via the `Image Deployment` GitHub Actions workflow. Push a tag in the form `scale-to-zero-image-v<N>` to trigger the build:
+
+```bash
+git tag scale-to-zero-image-v2.11.3
+git push origin scale-to-zero-image-v2.11.3
+```
+
+This produces:
+
+- `zopdev/scale-to-zero:v2.11.3`
+- `zopdev/scale-to-zero:latest`
+
+> **The tag is the Caddy version, not a version of this image.** `v2.11.3` means "Caddy 2.11.3" — it is not an incrementing counter like `db-init`'s. This is forced by the lockstep rule above: the deployer's component derives the tag it pulls from its own `CADDY_VERSION`, so the two must agree exactly. Bump this tag when Caddy is bumped, and re-tag with the same scheme if only the plugin changes (e.g. append a suffix) so the Caddy version stays readable.
+
+Consumers should pin the versioned tag, never `latest`.
+
+---
+
+## Contributing
+
+We welcome contributions to improve this Docker image. Please refer to the [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution guidelines.
+
+---
+
+## Code of Conduct
+
+To maintain a healthy and collaborative community, please adhere to our [Code of Conduct](../../CODE_OF_CONDUCT.md).
+
+---
+
+## License
+
+This project is licensed under the [LICENSE](../../LICENSE). Please review it for terms of use.
+
+---

--- a/images/scale-to-zero/README.md
+++ b/images/scale-to-zero/README.md
@@ -66,8 +66,8 @@ The plugin is **inert** unless a `sablier` directive appears in the Caddyfile, s
 The consumer is the ZopDay deployer's `scale-to-zero` VM component, which copies the binary onto the VM rather than running the container:
 
 ```bash
-docker pull zopdev/scale-to-zero:v2.11.3
-CID=$(docker create zopdev/scale-to-zero:v2.11.3)
+docker pull zopdev/scale-to-zero:v0.0.1
+CID=$(docker create zopdev/scale-to-zero:v0.0.1)
 docker cp "$CID:/usr/bin/caddy" /tmp/caddy
 docker rm "$CID"
 # validated against the live Caddyfile, then installed to /usr/local/bin/caddy
@@ -111,7 +111,7 @@ This produces:
 - `zopdev/scale-to-zero:v0.0.1`
 - `zopdev/scale-to-zero:latest`
 
-The image tag is an **independent, incrementing version** (same convention as `db-init` and `opentsdb`, both starting at `v0.0.1`) — it is deliberately *not* the Caddy version. Decoupling them means a plugin bump or a CVE rebuild of the same Caddy is just the next image tag, which would be impossible if the tag had to equal `CADDY_VERSION`.
+The image tag is an **independent, incrementing version** (matching the tags this repo has actually published — `db-init-image-v0.0.1` and `opentsdb-image-v0.0.1`) — it is deliberately *not* the Caddy version. Decoupling them means a plugin bump or a CVE rebuild of the same Caddy is just the next image tag, which would be impossible if the tag had to equal `CADDY_VERSION`.
 
 | Image tag | Caddy | Plugin |
 |---|---|---|

--- a/images/scale-to-zero/README.md
+++ b/images/scale-to-zero/README.md
@@ -102,18 +102,22 @@ images/scale-to-zero/
 The image is published via the `Image Deployment` GitHub Actions workflow. Push a tag in the form `scale-to-zero-image-v<N>` to trigger the build:
 
 ```bash
-git tag scale-to-zero-image-v2.11.3
-git push origin scale-to-zero-image-v2.11.3
+git tag scale-to-zero-image-v0.0.1
+git push origin scale-to-zero-image-v0.0.1
 ```
 
 This produces:
 
-- `zopdev/scale-to-zero:v2.11.3`
+- `zopdev/scale-to-zero:v0.0.1`
 - `zopdev/scale-to-zero:latest`
 
-> **The tag is the Caddy version, not a version of this image.** `v2.11.3` means "Caddy 2.11.3" — it is not an incrementing counter like `db-init`'s. This is forced by the lockstep rule above: the deployer's component derives the tag it pulls from its own `CADDY_VERSION`, so the two must agree exactly. Bump this tag when Caddy is bumped, and re-tag with the same scheme if only the plugin changes (e.g. append a suffix) so the Caddy version stays readable.
+The image tag is an **independent, incrementing version** (same convention as `db-init` and `opentsdb`, both starting at `v0.0.1`) — it is deliberately *not* the Caddy version. Decoupling them means a plugin bump or a CVE rebuild of the same Caddy is just the next image tag, which would be impossible if the tag had to equal `CADDY_VERSION`.
 
-Consumers should pin the versioned tag, never `latest`.
+| Image tag | Caddy | Plugin |
+|---|---|---|
+| `v0.0.1` | 2.11.3 | v1.0.2 |
+
+Consumers pin the **full tag** (`zopdev/scale-to-zero:v0.0.1`), never `latest` and never a tag derived from a version string. When Caddy is bumped: publish a new image tag *and* update both the consumer's pin and its `CADDY_VERSION` together — the lockstep in *Components & Versions* still applies, it is just enforced by the build assertions plus an explicit pin rather than by string arithmetic.
 
 ---
 
@@ -131,6 +135,10 @@ To maintain a healthy and collaborative community, please adhere to our [Code of
 
 ## License
 
-This project is licensed under the [LICENSE](../../LICENSE). Please review it for terms of use.
+**The image published from this Dockerfile is licensed under AGPL-3.0 — not Apache-2.0 like the rest of this repository.**
+
+[sablier-caddy-plugin](https://github.com/sablierapp/sablier-caddy-plugin) is AGPL-3.0, and Go statically links it into the Caddy binary, so the resulting artifact is a combined work governed by AGPL-3.0. Caddy itself is Apache-2.0, and the build files in this directory remain under the repository [LICENSE](../../LICENSE); the *binary and the published image* are what carry AGPL-3.0.
+
+Anyone distributing this image, or offering network access to software running it, takes on the corresponding AGPL-3.0 obligations — including making the complete corresponding source available. All of it is public: [Caddy](https://github.com/caddyserver/caddy), [the plugin](https://github.com/sablierapp/sablier-caddy-plugin), and this Dockerfile.
 
 ---


### PR DESCRIPTION
Adds `images/scale-to-zero` — Caddy with the [Sablier](https://sablierapp.dev) scale-to-zero plugin compiled in. Consumed by the ZopDay deployer's new `scale-to-zero` VM component (zopnight, separate PR), which stops idle services on a VM pool and starts them again on the next request.

## Why a custom image

The Sablier wake-on-request plugin is a Caddy **module**: it has to be compiled into the binary with `xcaddy` and cannot be loaded into a stock Caddy at runtime. Upstream publishes no prebuilt "Caddy + Sablier" binary, so we build one.

The two alternatives were worse: Caddy's official plugin download service always builds the *latest* Caddy (so we couldn't pin 2.11.3, see lockstep below) and makes every VM install depend on a third-party service being up; and building on the VM would need a Go toolchain everywhere.

## It's a carrier, not a runtime

Nothing runs this container in production. ZopDay VM pools run Caddy as a host systemd service (it binds `:80`/`:443` and reads `/etc/caddy`), so the component pulls the image and copies the binary out:

```bash
CID=$(docker create zopdev/scale-to-zero:v0.0.1)
docker cp "$CID:/usr/bin/caddy" /tmp/caddy && docker rm "$CID"
```

Docker Hub rather than a GitHub release asset because Docker is already a baseline component on every pool VM and those VMs already pull public images — no new registry auth, no new network path.

## Version lockstep (the thing to know when bumping)

`CADDY_VERSION` **must** match the version the deployer's baseline `caddy` component installs. Both variants report the *same* version string and differ only by the extra dormant module — that is exactly what lets the component's skip-download gate treat them as interchangeable. Bumping one without the other makes every prep re-download the binary forever.

The build asserts both invariants the deployer depends on, so a bad bump fails **here** instead of on a VM six steps later:

1. `caddy version` matches `^v<CADDY_VERSION> `
2. `caddy list-modules` contains `http.handlers.sablier`

The plugin is **inert** unless a `sablier` directive appears in the Caddyfile, so the binary is a safe drop-in replacement for stock Caddy of the same version.

## Follows the existing image conventions

- `images/scale-to-zero/{Dockerfile,README.md}`, same layout as `db-init` / `opentsdb`
- Builds with the shared `Image Deployment` workflow, no workflow changes
- Publishes on tag `scale-to-zero-image-v<N>` → `zopdev/scale-to-zero:v<N>` + `:latest`
- README mirrors `db-init`'s structure (Components & Versions, Prerequisites, Build, Usage, File Structure, Features, Publish, Contributing/CoC/License)

See *Tagging* below for the tag scheme. An earlier revision of this description argued for tagging with the **Caddy version** instead of a counter; that was changed in `2f97fae` after review, because it made a plugin-only or CVE rebuild of the same Caddy unreleasable.

## Verification

Built with the workflow's own invocation (context `images/`):

```
$ docker build -f images/scale-to-zero/Dockerfile -t scale-to-zero:prcheck images/
$ docker run --rm scale-to-zero:prcheck caddy version
v2.11.3 h1:/vFbdjcs2DtzcWTIxHybf5R5TspYFFThlZffChyBFHg=
$ docker run --rm scale-to-zero:prcheck caddy list-modules | grep sablier
http.handlers.sablier
```

Beyond the build, this exact image content was validated end-to-end before opening the PR: the rendered VM Caddyfile (`route { sablier … { names …; dynamic } reverse_proxy … }`) passes `caddy validate` against the binary, and a multi-arch build of it ran on a canary VM through a full sleep → wake cycle (idle service stopped, next request served the loading page, then the app).

## Licence

The Sablier plugin is **AGPL-3.0**, and Go links it statically, so the published image is a combined work under AGPL-3.0 — not Apache-2.0 like this repo. The README states this plainly.

The conditions are met: the complete corresponding source is public and **unmodified** (Caddy, the plugin, this Dockerfile — we compile the published plugin as-is, with no private fork), and no ZopDay code links against it (the orchestrator is a separate upstream container; the Caddy binary is a separate program the consuming component installs).

Publishing follows the normal path with no workflow changes.

## Tagging

Repo convention, matching the tags actually published here (`db-init-image-v0.0.1`, `opentsdb-image-v0.0.1`):

```bash
git tag scale-to-zero-image-v0.0.1
git push origin scale-to-zero-image-v0.0.1
```

The image tag is an independent counter, deliberately **not** the Caddy version — consumers pin the full tag, and the README records which Caddy each tag carries.

